### PR TITLE
Fixed Akai Homescreen User Icons positions

### DIFF
--- a/ResidentMenu/Abstract Layout/pieces/1_User Icons/Enable.json
+++ b/ResidentMenu/Abstract Layout/pieces/1_User Icons/Enable.json
@@ -21,6 +21,55 @@
 						"Y": 0.7
 					},
 					"Visible": true
+				},
+				{
+				    "PaneName": "L_BtnAccount_00",
+				    "Position": {
+					"X": 0
+				    },
+				    "Visible": true
+				},
+				{
+				    "PaneName": "L_BtnAccount_01",
+				    "Position": {
+					"X": 70
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_02",
+				    "Position": {
+					"X": 140
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_03",
+				    "Position": {
+					"X": 210
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_04",
+				    "Position": {
+					"X": 280
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_05",
+				    "Position": {
+					"X": 350
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_06",
+				    "Position": {
+					"X": 420
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_07",
+				    "Position": {
+					"X": 490
+				    }
 				}
 			]
 		}

--- a/ResidentMenu/Diamond Homescreen/pieces/1_User Icons/Enable.json
+++ b/ResidentMenu/Diamond Homescreen/pieces/1_User Icons/Enable.json
@@ -21,6 +21,55 @@
 						"Y": 0.7
 					},
 					"Visible": true
+				},
+				{
+				    "PaneName": "L_BtnAccount_00",
+				    "Position": {
+					"X": 0
+				    },
+				    "Visible": true
+				},
+				{
+				    "PaneName": "L_BtnAccount_01",
+				    "Position": {
+					"X": 70
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_02",
+				    "Position": {
+					"X": 140
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_03",
+				    "Position": {
+					"X": 210
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_04",
+				    "Position": {
+					"X": 280
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_05",
+				    "Position": {
+					"X": 350
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_06",
+				    "Position": {
+					"X": 420
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_07",
+				    "Position": {
+					"X": 490
+				    }
 				}
 			]
 		}

--- a/ResidentMenu/Small Compact Homescreen/pieces/3_User Icons/Enable.json
+++ b/ResidentMenu/Small Compact Homescreen/pieces/3_User Icons/Enable.json
@@ -21,6 +21,55 @@
 						"Y": 0.7
 					},
 					"Visible": true
+				},
+				{
+				    "PaneName": "L_BtnAccount_00",
+				    "Position": {
+					"X": 0
+				    },
+				    "Visible": true
+				},
+				{
+				    "PaneName": "L_BtnAccount_01",
+				    "Position": {
+					"X": 70
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_02",
+				    "Position": {
+					"X": 140
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_03",
+				    "Position": {
+					"X": 210
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_04",
+				    "Position": {
+					"X": 280
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_05",
+				    "Position": {
+					"X": 350
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_06",
+				    "Position": {
+					"X": 420
+				    }
+				},
+				{
+				    "PaneName": "L_BtnAccount_07",
+				    "Position": {
+					"X": 490
+				    }
 				}
 			]
 		}


### PR DESCRIPTION
FIX L_BtnAccount positions for 3 themes: Abstract, Diamond, Small Compact

Some user icons were off screen since their individual positions were not changed in this piece